### PR TITLE
Remove hard exiting in Media Proxy

### DIFF
--- a/media-proxy/src/media_proxy.cc
+++ b/media-proxy/src/media_proxy.cc
@@ -234,7 +234,6 @@ int main(int argc, char* argv[])
     sdkApiThread.join();
 
     log::info("Media Proxy exited");
-    exit(0);
 
     return 0;
 }


### PR DESCRIPTION
Hard exiting with exit() is no longer needed after legacy TCP API support is removed.